### PR TITLE
Update dokku-alt-manager to work on Ubuntu 16.04 with PHP 7.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,16 @@ RUN apt-get update && \
         curl \
         git \
         apache2 \
-        libapache2-mod-php5 \
-        php5-mysql \
-        php5-gd \
-        php5-curl \
+        libapache2-mod-php7.0 \
+        php7.0-mysql \
+        php7.0-gd \
+        php7.0-curl \
         php-pear \
-        php-apc && \
+        php-apcu && \
     rm -rf /var/lib/apt/lists/*
 
-RUN sed -i "s/variables_order.*/variables_order = \"EGPCS\"/g" /etc/php5/apache2/php.ini
-RUN sed -i "s/variables_order.*/variables_order = \"EGPCS\"/g" /etc/php5/cli/php.ini
+RUN sed -i "s/variables_order.*/variables_order = \"EGPCS\"/g" /etc/php/7.0/apache2/php.ini
+RUN sed -i "s/variables_order.*/variables_order = \"EGPCS\"/g" /etc/php/7.0/cli/php.ini
 RUN sed -i "s/# StrictHostKeyChecking ask/ StrictHostKeyChecking no/g" /etc/ssh/ssh_config
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         }
     },
     "require": {
-        "atk4/atk4": "4.3.*@dev",
-        "phpseclib/phpseclib": "0.3.*@dev"
+        "atk4/atk4": "^4.3",
+        "phpseclib/phpseclib": "^2.0"
     },
     "extra": {
       "heroku": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,25 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "bd3448950b1c0d1af1c6bdbdc6bd225f",
+    "hash": "264f8459a9fa64d8ff089b08666b5114",
+    "content-hash": "017802ee28decbb68a352542359ac969",
     "packages": [
         {
             "name": "atk4/atk4",
-            "version": "4.3.x-dev",
+            "version": "4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/atk4/atk4.git",
-                "reference": "origin/4.3"
+                "reference": "0eb774a28165db5cca5b0520851d212f11ade6f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "http://agiletoolkit.org/distfiles/agiletoolkit-4.2.4.zip",
-                "reference": null,
-                "shasum": null
+                "url": "https://api.github.com/repos/atk4/atk4/zipball/0eb774a28165db5cca5b0520851d212f11ade6f9",
+                "reference": "0eb774a28165db5cca5b0520851d212f11ade6f9",
+                "shasum": ""
             },
             "type": "library",
             "autoload": {
@@ -29,63 +31,55 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
             "homepage": "https://agiletoolkit.org/",
             "keywords": [
                 "atk4",
                 "framework"
             ],
-            "time": "2014-11-03 03:09:22"
+            "time": "2016-02-29 12:21:49"
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "dev-master",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "c6e88ca6e81bc5a2d7161658e16a95b7ef8d6ad1"
+                "reference": "3d265f7c079f5b37d33475f996d7a383c5fc8aeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/c6e88ca6e81bc5a2d7161658e16a95b7ef8d6ad1",
-                "reference": "c6e88ca6e81bc5a2d7161658e16a95b7ef8d6ad1",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/3d265f7c079f5b37d33475f996d7a383c5fc8aeb",
+                "reference": "3d265f7c079f5b37d33475f996d7a383c5fc8aeb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.0.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phing/phing": "2.7.*",
-                "phpunit/phpunit": "4.0.*",
-                "sami/sami": "1.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "phing/phing": "~2.7",
+                "phpunit/phpunit": "~4.0",
+                "sami/sami": "~2.0",
+                "squizlabs/php_codesniffer": "~2.0"
             },
             "suggest": {
                 "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
-                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a wide variety of cryptographic operations.",
-                "pear-pear/PHP_Compat": "Install PHP_Compat to get phpseclib working on PHP < 4.3.3."
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.3-dev"
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib\\": "phpseclib/"
                 }
             },
-            "autoload": {
-                "psr-0": {
-                    "Crypt": "phpseclib/",
-                    "File": "phpseclib/",
-                    "Math": "phpseclib/",
-                    "Net": "phpseclib/",
-                    "System": "phpseclib/"
-                },
-                "files": [
-                    "phpseclib/Crypt/Random.php"
-                ]
-            },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                "phpseclib/"
-            ],
             "license": [
                 "MIT"
             ],
@@ -108,6 +102,11 @@
                 {
                     "name": "Hans-Jürgen Petrich",
                     "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
                     "role": "Developer"
                 }
             ],
@@ -132,16 +131,15 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2014-11-10 03:08:59"
+            "time": "2016-05-13 01:15:21"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "atk4/atk4": 20,
-        "phpseclib/phpseclib": 20
-    },
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": [],
     "platform-dev": []
 }

--- a/config-default.php
+++ b/config-default.php
@@ -2,7 +2,7 @@
 $config['url_prefix']='?page=';
 $config['url_postfix']='';
 
-$config['js']['versions']['jqueryui']='1.11.master';
+//$config['js']['versions']['jqueryui']='1.11.master';
 
 $config['dsn']='mysql://root:root@localhost/dam';
 

--- a/shared/addons/dokku_alt/lib/Model/Access.php
+++ b/shared/addons/dokku_alt/lib/Model/Access.php
@@ -32,7 +32,7 @@ class Model_Access extends  \SQL_Model {
 
     function generateAndAdd()
     {
-        $rsa = new \Crypt_RSA();
+        $rsa = new \phpseclib\Crypt\RSA();
         $rsa->setPublicKeyFormat(CRYPT_RSA_PUBLIC_FORMAT_OPENSSH);
         $this->set($rsa->createKey());
         $this->save();

--- a/shared/addons/dokku_alt/lib/Model/Host.php
+++ b/shared/addons/dokku_alt/lib/Model/Host.php
@@ -23,7 +23,7 @@ class Model_Host extends \SQL_Model {
     function connect(){
         try {
 
-            $ssh = new \Net_SSH2($this['addr'], $this['ssh_port'] ? : 22);
+            $ssh = new \phpseclib\Net\SSH2($this['addr'], $this['ssh_port'] ? : 22);
             $key=$this->getPrivateKey();
 
             if (!$ssh->login($this['ssh_user'] ? : 'dokku', $key)) {
@@ -37,7 +37,7 @@ class Model_Host extends \SQL_Model {
     }
 
     function getPrivateKey(){
-        $key = new \Crypt_RSA();
+        $key = new \phpseclib\Crypt\RSA();
 
         if($this['private_key']){
             $key->loadKey($this['private_key']);

--- a/shared/lib/Model/Keychain.php
+++ b/shared/lib/Model/Keychain.php
@@ -27,7 +27,7 @@ class Model_Keychain extends SQL_Model {
      * passphrase works
      */
     function verify() {
-        $rsa = new Crypt_RSA();
+        $rsa = new \phpseclib\Crypt\RSA();
 
         $rsa->loadKey($this['notes']);
         $encrypt = $rsa->encrypt('test');
@@ -46,7 +46,7 @@ class Model_Keychain extends SQL_Model {
      * Returns Crypt_RSA object with decrypted private key.
      */
     function getPrivateKey(){
-        $key = new \Crypt_RSA();
+        $key = new \phpseclib\Crypt\RSA();
 
         $pack = $this->app->getPackingKey();
         if($pack)$key->setPassword($pack);


### PR DESCRIPTION
These changes bring support for Ubuntu 16.04
- As the Docker Library ubuntu:latest now points to Ubuntu 16.04 there were various issues with installing this package. Ubuntu 16.04 comes with php7 so the Dockerfile has been changed to update to php7.
- There were issues finding the jqueryui-1.11-master.js file that was hard configured into the config-default.php file, i have commented out this line so atk4 will pick the version it has available in its package.
- There were issues connecting to a dokku host caused by phpseclib, So i have updated to current version.
- Removed the dev tags from the composer.json file.
- Scripts could not find the include files for the phpseclib classes so I updated the calls to the phpseclib classes from \Net_SSH2 to \phpseclib\Net\SSH2

I have just tested this with the dokku manager:install after modifiying the DOKKU_ALT_MANAGER_REPOSITORY in the /var/lib/dokku-alt/plugins/dokku-alt-manager/commands file and installation completes and can communicate with dokku hosts.
